### PR TITLE
タイトルシーンの点滅アルファ値の上限値修正

### DIFF
--- a/Assets/Scenes/TitleScene.unity
+++ b/Assets/Scenes/TitleScene.unity
@@ -608,8 +608,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0}
-  m_RaycastTarget: 1
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -660,7 +660,7 @@ MonoBehaviour:
   _fadePanel: {fileID: 989122082}
   _isBlink: 1
   _blinkSpeed: 1
-  _maxBlinkAlpha: 0.5
+  _maxBlinkAlpha: 0.7
 --- !u!1 &1496006011
 GameObject:
   m_ObjectHideFlags: 0
@@ -842,6 +842,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 464778f928d724447883fccf06d7e6c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _fadeControl: {fileID: 989122083}
   _startButton: {fileID: 371835334}
 --- !u!1 &1893433785
 GameObject:

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,8 +6,14 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/TitleScene.unity
+    guid: 5596b4ef164812a4d9c5ccb2de8f2437
+  - enabled: 1
     path: Assets/Scenes/GameScene.unity
     guid: 8c9cfa26abfee488c85f1582747f6a02
+  - enabled: 1
+    path: Assets/Scenes/ResultScene.unity
+    guid: 37312600747a60c42abef77061cee624
   m_configObjects:
     com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 2bcd2660ca9b64942af0de543d8d7100, type: 3}
   m_UseUCBPForAssetBundles: 0


### PR DESCRIPTION
タイトルシーンの点滅時のアルファ値上限を変更しました。
ずっと追加を忘れていたBuildSettingsも追加。

こちらで全てプッシュ完了です。
ゲームとして動きます。
<img width="1071" height="601" alt="image" src="https://github.com/user-attachments/assets/a5530ea8-e89c-4948-a34b-259d0aa54583" />
<img width="889" height="502" alt="image" src="https://github.com/user-attachments/assets/1a4dabca-b7af-472a-85e3-39789aa41902" />