### PR TITLE
ゲームシーン変更に伴うリザルトシーンの変更修正

### DIFF
--- a/Assets/Scenes/ResultScene.unity
+++ b/Assets/Scenes/ResultScene.unity
@@ -130,6 +130,7 @@ GameObject:
   - component: {fileID: 232373804}
   - component: {fileID: 232373803}
   - component: {fileID: 232373802}
+  - component: {fileID: 232373805}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -211,6 +212,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &232373805
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 232373801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
 --- !u!1 &287737998
 GameObject:
   m_ObjectHideFlags: 0
@@ -1031,13 +1076,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1487829060}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ccd725e0b5efdc646b62a3df51ea2907, type: 3}
+  m_Script: {fileID: 11500000, guid: 6aa55e3938fab9d44a4dee458a474d62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   _fadePanel: {fileID: 1487829062}
   _isBlink: 1
   _blinkSpeed: 0.3
-  _maxBlinkAlpha: 0.35
+  _maxBlinkAlpha: 0.6
 --- !u!114 &1487829064
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
リザルトシーンのアタッチが外れていたのを付けなおしました。
フェードの再設定。
元に戻しただけですので、見た目の変更は特にありません。